### PR TITLE
Collector: add `standaloneCloseRecordsTotal` metric for unmatched file closes

### DIFF
--- a/collector/correlator.go
+++ b/collector/correlator.go
@@ -752,6 +752,7 @@ func (c *Correlator) handleFileClose(rec parser.FileCloseRecord, packet *parser.
 	val, exists := c.stateMap.Get(key)
 	if !exists {
 		c.logger.Debugf("No open record found for file close: serverID=%s, fileID=%d - creating standalone record", serverID, rec.Header.FileId)
+		standaloneCloseRecordsTotal.Inc()
 		// No open record found, create a standalone close record
 		return c.createStandaloneCloseRecord(rec, packet), nil
 	}

--- a/collector/correlator_test.go
+++ b/collector/correlator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/opensciencegrid/xrootd-monitoring-shoveler/parser"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1301,6 +1302,81 @@ func TestExtractHostFromRemoteAddr_UnbracketedIPv6WithShortPort(t *testing.T) {
 	// Ambiguous case: full string is also a syntactically valid IPv6 literal,
 	// so parser should preserve it as-is rather than truncate.
 	assert.Equal(t, addr, extractHostFromRemoteAddr(addr))
+}
+
+// TestStandaloneCloseRecordsTotal verifies that the shoveler_standalone_close_records_total
+// counter increments exactly once for each file close that has no matching open in stateMap.
+func TestStandaloneCloseRecordsTotal(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	before := testutil.ToFloat64(standaloneCloseRecordsTotal)
+
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{
+			RecType: parser.RecTypeClose,
+			FileId:  42,
+			UserId:  7,
+		},
+		Xfr: parser.StatXFR{Read: 512},
+	}
+	closePacket := &parser.Packet{
+		Header:      parser.Header{Code: parser.PacketTypeFStat, ServerStart: 9000},
+		FileRecords: []interface{}{closeRec},
+	}
+
+	recs, err := correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "standalone close should still produce a record")
+	assert.Equal(t, "unknown", recs[0].Filename, "standalone close should have unknown filename")
+
+	after := testutil.ToFloat64(standaloneCloseRecordsTotal)
+	assert.Equal(t, float64(1), after-before, "counter should increment by 1 for each unmatched close")
+
+	// A second unmatched close for the same fileID should increment again.
+	recs, err = correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+
+	assert.Equal(t, float64(2), testutil.ToFloat64(standaloneCloseRecordsTotal)-before,
+		"counter should reflect all unmatched closes, not just the first")
+}
+
+// TestStandaloneCloseCounterNotIncrementedOnCorrelatedClose verifies that a
+// file close that successfully correlates with an open does NOT increment the counter.
+func TestStandaloneCloseCounterNotIncrementedOnCorrelatedClose(t *testing.T) {
+	correlator := NewCorrelator(5*time.Second, 0, nil)
+	defer correlator.Stop()
+
+	before := testutil.ToFloat64(standaloneCloseRecordsTotal)
+
+	openRec := parser.FileOpenRecord{
+		Header:   parser.FileHeader{RecType: parser.RecTypeOpen, FileId: 55, UserId: 1},
+		FileSize: 2048,
+		Lfn:      []byte("/data/correlated.root"),
+	}
+	openPacket := &parser.Packet{
+		Header:      parser.Header{ServerStart: 5000},
+		FileRecords: []interface{}{openRec},
+	}
+	_, err := correlator.ProcessPacket(openPacket)
+	require.NoError(t, err)
+
+	closeRec := parser.FileCloseRecord{
+		Header: parser.FileHeader{RecType: parser.RecTypeClose, FileId: 55, UserId: 1},
+		Xfr:    parser.StatXFR{Read: 1024},
+	}
+	closePacket := &parser.Packet{
+		Header:      parser.Header{ServerStart: 5000},
+		FileRecords: []interface{}{closeRec},
+	}
+	recs, err := correlator.ProcessPacket(closePacket)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "/data/correlated.root", recs[0].Filename, "correlated close should have correct filename")
+
+	assert.Equal(t, before, testutil.ToFloat64(standaloneCloseRecordsTotal),
+		"correlated close must not increment the standalone counter")
 }
 
 // TestPacketTypeName verifies that XRootD monitoring packet types are correctly mapped

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -26,4 +26,14 @@ var (
 		Name: "shoveler_packets_by_server_total",
 		Help: "Total number of successfully parsed monitoring packets per upstream server IP and XRootD stream type",
 	}, []string{"server_ip", "packet_type"})
+
+	// standaloneCloseRecordsTotal counts file close records for which no matching
+	// open was found in stateMap. These records are emitted via createStandaloneCloseRecord
+	// and are degraded: they lack LFN, open-time, and full user context. A sustained
+	// rise here indicates the correlator is missing opens (e.g. due to packet loss,
+	// TTL expiry, or shoveler restart mid-session).
+	standaloneCloseRecordsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "shoveler_standalone_close_records_total",
+		Help: "Total number of file close records emitted without a matching open in stateMap (degraded records missing LFN, open-time, and full user context)",
+	})
 )


### PR DESCRIPTION
Fixes #9 